### PR TITLE
Add integration test tag to linter

### DIFF
--- a/{{cookiecutter.project_slug}}/.golangci.yaml
+++ b/{{cookiecutter.project_slug}}/.golangci.yaml
@@ -4,6 +4,8 @@ run:
   tests: true
   skip-dirs:
     - .coverage
+  build-tags:
+    - integration
 output:
   format: colored-line-number
   print-issued-lines: true


### PR DESCRIPTION
This enables linting of files we've marked for integration testing.